### PR TITLE
Fix link to the new Noita wiki

### DIFF
--- a/bangs/entertainment/games/specific.json
+++ b/bangs/entertainment/games/specific.json
@@ -1132,7 +1132,7 @@
   {
     "bang": "noita",
     "name": "Noita Wiki",
-    "url": "https://noita.gamepedia.com/{{{s}}}"
+    "url": "https://noita.wiki.gg/{{{s}}}"
   },
   {
     "bang": "nook",


### PR DESCRIPTION
The Noita wiki has been migrated and actively developed on noita.wiki.gg